### PR TITLE
Do not truncate counters to 32 bit

### DIFF
--- a/agent/checks/diskio.ps1
+++ b/agent/checks/diskio.ps1
@@ -18,13 +18,13 @@ Function run()
         $instance += " " + $_.Name.Replace(" ","_")
         $instancecount++
 
-        $avg_disk_queue       += " " + $_.AvgDiskQueueLength % ([math]::pow(2,32))
-        $avg_disk_read_queue  += " " + $_.AvgDiskReadQueueLength % ([math]::pow(2,32))
-        $avg_disk_write_queue += " " + $_.AvgDiskWriteQueueLength % ([math]::pow(2,32))
+        $avg_disk_queue       += " " + $_.AvgDiskQueueLength
+        $avg_disk_read_queue  += " " + $_.AvgDiskReadQueueLength
+        $avg_disk_write_queue += " " + $_.AvgDiskWriteQueueLength
         $disk_read_sec        += " " + $_.DiskReadsPersec
         $disk_write_sec       += " " + $_.DiskWritesPersec
-        $disk_readbyte_sec    += " " + $_.DiskReadBytesPersec % ([math]::pow(2,32))
-        $disk_writebyte_sec   += " " + $_.DiskWriteBytesPersec % ([math]::pow(2,32))
+        $disk_readbyte_sec    += " " + $_.DiskReadBytesPersec
+        $disk_writebyte_sec   += " " + $_.DiskWriteBytesPersec
     }
     Send-Line ""
     Send-Line "<<<winperf_phydisk>>>"


### PR DESCRIPTION
The diskio counters should not be truncated on 32bit, this causes the counters to wrap around regularly even on medium I/O load.

Fixed in the official agent in http://git.mathias-kettner.de/git/?p=check_mk.git;a=commitdiff;h=3fd6d0c8a9a0b30f8a9b46e5db1335621a538496;hp=88f36c8de2c90b9cbed1c88f5ae1cf5b02fa5110
