### PR TITLE
windowsupdate.ps1: misc bug fixes

### DIFF
--- a/agent/checks/hyperv_vms.ps1
+++ b/agent/checks/hyperv_vms.ps1
@@ -31,7 +31,7 @@ Function run2008r2() {
 			"32770" { $state="Starting" }
 			default { $state="Unknown" }
 		}
-		$uptime = 0
+		$uptime = "00:00:00"
 		#$uptime = (Get-Date) - ($_.TimeOfLastStateChange)
 		#write-host $_.ElementName $state $uptime $_.StatusDescriptions[0]
 		Send-Line ($_.ElementName+" "+$state+" "+$uptime+" "+$_.StatusDescriptions[0])


### PR DESCRIPTION
- only send the section at all if there is content (otherwise
  windows_updates.vbs is likely still running)
- send old content before clobbering the file
- really create an empty statefile to avoid sending bogus OK result
  (can probably be dropped completely)
- Test for windows updates every hour, the argument for LogRefreshNeeded
  is measured in minutes, so the previous 3600 value would have been 2.5
  days ... this is most likely a unit error
